### PR TITLE
Testing: tweeters no en system:playback1-2

### DIFF
--- a/custom/brutefir_ejemplo2vias.ini
+++ b/custom/brutefir_ejemplo2vias.ini
@@ -31,10 +31,10 @@ in_R =
 # el nombre del (los) subwoofer sería sw_N (con N >= 1)
 
 # via  = jack-port                   levelAtten  polarity   delay(ms)
-hi_l   = system:playback_1               0.0       1          0
-hi_r   = system:playback_2               0.0       1          0
 lo_l   = system:playback_1               0.0       1          0
 lo_r   = system:playback_2               0.0       1          0
+hi_l   = system:playback_3               0.0       1          0
+hi_r   = system:playback_4               0.0       1          0
 
 # NOTA sobre levelAtten: ver la Guia del usuario.
 

--- a/lspk/ejemplo2vias/44100/brutefir_config
+++ b/lspk/ejemplo2vias/44100/brutefir_config
@@ -28,8 +28,8 @@ input "in_L", "in_R" {
 output "hi_L", "hi_R", "lo_L", "lo_R" {
 	# mapeo de las 4 salidas:
 	device: "jack" { ports:
-	"system:playback_1"/"hi_L", "system:playback_2"/"hi_R", 
-	"system:playback_1"/"lo_L", "system:playback_2"/"lo_R";
+	"system:playback_1"/"lo_L", "system:playback_2"/"lo_R",
+	"system:playback_3"/"hi_L", "system:playback_4"/"hi_R"; 
 	};
 	sample:   "AUTO";
 	channels: 4/0,1,2,3;


### PR DESCRIPTION
Buenas prácticas: se prefiere dejar las vias delicadas (los tweeters) en puertos de jack por encima de system:playback_1/2 ya que un accidente de conexción errónea en jack suele ir a esos dos primeros puertos de playback. Mejor dejar ahí un woofer o midwoofer.