### PR TITLE
Master rr

### DIFF
--- a/bin/client_mpd.py
+++ b/bin/client_mpd.py
@@ -10,7 +10,7 @@
 import os
 import mpd # mpd is replaced by python-mpd2
 import client as firtroClient
-from math import log10
+from math import log
 
 def connect_mpd(mpd_host=None, mpd_port=None, mpd_passwd=None):
     """Connect to mpd.
@@ -43,8 +43,8 @@ def idle_loop(c):
         #### ... .. when something happens, idle ends.
 
         newVol = c.status()['volume']
-        # Ajustamos la ganancia en FIRtro:
-        g = str(int(newVol) - 100)
+        # set FIRtro gain:
+        g = str(int(round(((log(1+float(newVol)/100)/log(2))**1.293-1)*slider_range)))
         firtroClient.firtro_socket("gain " + g, quiet=True)
                         
 def setvol(vol):
@@ -55,6 +55,10 @@ def setvol(vol):
         c.disconnect()
     except:
         print "(client_mpd) Ha habido un problema intentando establecer el volumen en MPD."
+
+# Slider volume range 
+slider_range = 30
+slider_range = abs(int(slider_range)) # Must be positive integer
 
 if __name__ == "__main__" or __name__ == "main":
 

--- a/bin/server_process.py
+++ b/bin/server_process.py
@@ -57,6 +57,9 @@ from getspeaker import *        # OjO tomarermos system_eq del archivo de config
 from getinputs import inputs
 from subprocess import Popen
 from math import copysign
+from math import log
+from math import log10
+from math import exp
 import numpy as np
 from scipy import signal
 
@@ -824,8 +827,10 @@ def do (order):
                     # AMR 2º Entrada de brutefir (para analogica con filtros mp):
                     #bf_cli('cfia 2 2 m0; cfia 3 3 m0')
                 if not gain_direct and "level" in order:        ## <MPD> ##
-                    # actualizamos el "falso volumen" de MPD
-                    client_mpd.setvol(100 + gain)
+                    # update MPD "fake volume"
+                    vol = 100*(exp(max((gain/client_mpd.slider_range+1),0)**(1/1.293)*log(2))-1)
+                    if vol < 1: vol = 1 # minimal mpd volume
+                    client_mpd.setvol(vol)
                     last_level_change_timestamp = time.time()
                 
             if change_eq:


### PR DESCRIPTION
Se ha mejorado el cálculo de los volúmenes conectados de mpd y FIRtro de modo que la barra de volumen de los clientes de MPD tenga un comportamiento logarítmico.
La variable de rango del slider de los clientes se añade por las bravas a _client_mpd.py_, pero tal vez se podría poner como variable de configuración de MPD en ~/audio/config. Sopésese :-)