### PR TITLE
Mpd vol slider

### DIFF
--- a/audio/config.example
+++ b/audio/config.example
@@ -116,6 +116,7 @@ mpd_path = /usr/bin/mpd
 mpd_options = 
 ; El volumen de MPD puede gobernar el volumen de FIRtro (OjO en fase BETA):
 mpd_volume_linked2firtro = False
+mpd_volume_slider_range = 30
 
 ; -- MPLAYER -- Opcional (se carga una instancia por cada servicio cdda y/o tdt)
 mplayer_path = /usr/bin/mplayer

--- a/bin/client_mpd.py
+++ b/bin/client_mpd.py
@@ -12,6 +12,10 @@ import mpd # mpd is replaced by python-mpd2
 import client as firtroClient
 from math import log
 
+# Slider volume range as per audio/config
+from getconfig import mpd_volume_slider_range as slider_range
+slider_range = abs(int(slider_range)) # Must be positive integer
+
 def connect_mpd(mpd_host=None, mpd_port=None, mpd_passwd=None):
     """Connect to mpd.
     """
@@ -32,7 +36,6 @@ def connect_mpd(mpd_host=None, mpd_port=None, mpd_passwd=None):
     if mpd_passwd is not None:
         client.password(mpd_passwd)
     return client
-
 
 def idle_loop(c):
     """MPD idle loop (daemon mode)
@@ -55,10 +58,6 @@ def setvol(vol):
         c.disconnect()
     except:
         print "(client_mpd) Ha habido un problema intentando establecer el volumen en MPD."
-
-# Slider volume range 
-slider_range = 30
-slider_range = abs(int(slider_range)) # Must be positive integer
 
 if __name__ == "__main__" or __name__ == "main":
 

--- a/bin/getconfig.py
+++ b/bin/getconfig.py
@@ -64,6 +64,7 @@ load_mpd =                  config.getboolean('path', 'load_mpd')
 mpd_path =                  config.get('path', 'mpd_path')
 mpd_options =               config.get('path', 'mpd_options')
 mpd_volume_linked2firtro =  config.getboolean('path', 'mpd_volume_linked2firtro')
+mpd_volume_slider_range =   config.getint('path', 'mpd_volume_slider_range')
 
 load_mplayer_tdt  =         config.getboolean('path', 'load_mplayer_tdt')
 load_mplayer_cdda =         config.getboolean('path', 'load_mplayer_cdda')


### PR DESCRIPTION
continues improvements on MPD volume calculation, log volume slider range for mpd clients becomes configurable on `audio/config`

```
; ---- FUENTES: ----

; -- MPD -- Opcional
load_mpd = False
mpd_path = /usr/bin/mpd
mpd_options = 
; El volumen de MPD puede gobernar el volumen de FIRtro (OjO en fase BETA):
mpd_volume_linked2firtro = False
mpd_volume_slider_range = 30
```