### PR TITLE
New displays section

### DIFF
--- a/audio/config.example
+++ b/audio/config.example
@@ -13,13 +13,6 @@ command_delay = .5
 ; -- Opciones de la orden "beep" para indicar carga del FIRtro
 beep_options = 
 
-; -- Usar LCD externo (requiere servicio LCDproc accesible))
-enable_lcd = False
-; tiempo de presentacion de informaciones temporales
-lcd_info_timeout = 1
-; opcion de presentacion LCD (consultar con "bin/server_lcdproc.py -h" )
-lcd_layout = 1
-
 ; -- Tope de ganancia (dB) admitada en Brutefir.
 gmax = 0
 ; -- Tonos a cero en el arranque (True/False)
@@ -125,9 +118,9 @@ mplayer_options = -quiet -nolirc
 
 ; -- SHAIRPORT -- Opcional (FIRtro como altavoz AirPlay)
 load_shairport = False
-; Ejemplo de path para ejecutable compilado a mano:
+; Ejemplo de path para ejecutable compilado a mano (ver en Wiki):
 ;shairport_path = /usr/local/bin/shairport
-; Ejemplo de path para programa instalado con apt Debian
+; Ejemplo de path para programa instalado con apt Debian (ver en Wiki)
 shairport_path = shairport-sync
 ; Ejemplo de opciones para salida por Pulseaudio (con shairport-sync indicar '-o pa')
 ; shairport_options = -a FirtroSalon -o pulse
@@ -166,12 +159,6 @@ jacktrip_options = -c rpi2fir -r 2 --nojackportsconnect
 load_irexec = False
 irexec_path = /usr/bin/irexec
 irexec_options = -d
-
-; -- DISPLAY de MPD en el LCD -- Opcional                                       
-; https://pypi.python.org/pypi/mpdlcd
-load_mpdlcd = False
-mpdlcd_path = /usr/local/bin/mpdlcd
-mpdlcd_options =
 
 [net]
 ;-- dirección IP del FIRtro
@@ -219,3 +206,19 @@ tone_variation = 6
 loudness_variation = 10
 balance_variation = 6
 no_phase_xo = lp
+
+[displays]
+; --- Configuraciones para visualizar información (LCD, INFOFIFO, etc)
+
+; -- Usar LCD externo (requiere servicio LCDproc accesible))
+enable_lcd = False
+; tiempo de presentacion de informaciones temporales
+lcd_info_timeout = 1
+; opcion de presentacion LCD (consultar con "bin/server_lcdproc.py -h" )
+lcd_layout = 1
+
+; -- DISPLAY de MPD en el LCD -- Opcional                                       
+; https://pypi.python.org/pypi/mpdlcd
+load_mpdlcd = False
+mpdlcd_path = /usr/local/bin/mpdlcd
+mpdlcd_options =

--- a/bin/getconfig.py
+++ b/bin/getconfig.py
@@ -22,10 +22,6 @@ tone_defeat_on_startup =    config.getboolean('misc', 'tone_defeat_on_startup')
 command_delay =             config.getfloat('misc', 'command_delay')
 beep_options =              config.get('misc', 'beep_options')
 
-enable_lcd =                config.getboolean('misc', 'enable_lcd')
-lcd_info_timeout =          config.getfloat('misc', 'lcd_info_timeout')
-lcd_layout =                config.get('misc', 'lcd_layout')
-
 dummy_ports =               config.get('misc', 'dummy_ports')
 pause_players =             config.getboolean('misc', 'pause_players')
 resume_players =            config.getboolean('misc', 'resume_players')
@@ -93,10 +89,6 @@ load_netjack =              config.getboolean('path', 'load_netjack')
 netjack_path =              config.get('path', 'netjack_path')
 netjack_options =           config.get('path', 'netjack_options')
 
-load_mpdlcd =               config.getboolean('path', 'load_mpdlcd')
-mpdlcd_path =               config.get('path', 'mpdlcd_path')
-mpdlcd_options =            config.get('path', 'mpdlcd_options')
-
 load_irexec =               config.getboolean('path', 'load_irexec')
 irexec_path =               config.get('path', 'irexec_path')
 irexec_options =            config.get('path', 'irexec_options')
@@ -141,3 +133,13 @@ treble_pha_path =           config_folder + treble_pha_filename
 bass_mag_path =             config_folder + bass_mag_filename
 bass_pha_path =             config_folder + bass_pha_filename
 freq_path =                 config_folder + freq_filename
+
+#[displays]
+enable_lcd =                config.getboolean('displays', 'enable_lcd')
+lcd_info_timeout =          config.getfloat  ('displays', 'lcd_info_timeout')
+lcd_layout =                config.get       ('displays', 'lcd_layout')
+
+load_mpdlcd =               config.getboolean('displays', 'load_mpdlcd')
+mpdlcd_path =               config.get       ('displays', 'mpdlcd_path')
+mpdlcd_options =            config.get       ('displays', 'mpdlcd_options')
+


### PR DESCRIPTION
Nueva sección [displays] en audio/config y reapunte en bin/getconfig.py

```
[displays]
; --- Configuraciones para visualizar información
  ; -- Usar LCD externo // viene de [misc]
  ; -- DISPLAY de MPD en el LCD // viene de [path]
```

Sirve para que un "master" pueda migrar con comodidad a la branch "info_display" que tiene más opciones de visualización ya reorganizadas en la nueva sección [displays]. Hace tiempo que lo tenía pendiente ...
