### PR TITLE
Correct radio channels not updating in status file

### DIFF
--- a/bin/server_process.py
+++ b/bin/server_process.py
@@ -321,6 +321,9 @@ def do (order):
         print "(server_process) Command:", order
 
     try:
+        radio = status.get('inputs', 'radio')
+        radio_prev = status.get('inputs', 'radio_prev')
+
         if command == "status":
             write_status = False
 


### PR DESCRIPTION
Reads status values related to radio channels, in order to get posiible modifications by radio_channels.py. Before this mod status values were overwritten by the values found at startup.